### PR TITLE
dev_haibt

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -86,7 +86,13 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService
             .getDiscoveryConfigurationByNameOrDso(configuration, scopeObject);
 
-        return discoverConfigurationConverter.convert(discoveryConfiguration, utils.obtainProjection());
+        // Set values for searchConfigurationRest here, since there are no possible ways to get them from
+        //   DiscoveryConfiguration object
+        SearchConfigurationRest searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration
+                , utils.obtainProjection());
+        searchConfigurationRest.setConfiguration(configuration);
+        searchConfigurationRest.setScope(dsoScope);
+        return searchConfigurationRest;
     }
 
     public SearchResultsRest getSearchObjects(final String query, final List<String> dsoTypes, final String dsoScope,

--- a/dspace-server-webapp/src/main/resources/application.properties
+++ b/dspace-server-webapp/src/main/resources/application.properties
@@ -130,3 +130,6 @@ spring.servlet.multipart.max-file-size = 512MB
 
 # Maximum size of a multipart request (i.e. max total size of all files in one request) (default = 10MB)
 spring.servlet.multipart.max-request-size = 512MB
+
+## Maximum page size per request (default = 1000)
+spring.data.rest.max-page-size=9999


### PR DESCRIPTION
# References
Fix [#8576](https://github.com/DSpace/DSpace/issues/8576), [#8577](https://github.com/DSpace/DSpace/issues/8577)
# Description
This fixes warning when self links returned from RestAPI do not match the request's URL.


1. For #8576 the reason is that the converted `searchConfigurationRest` do not hold values of request parameters `configuration` and `scope`, due to the original DiscoveryConfiguration object do not store these value. The fix is simply setting them in `DiscoveryRestRepository.getSearchConfiguration()`


2. For #8577, the maximum value for a `Pageable` page size is 1000 as default per spring doc, so if parameter `size` is set above this limit the value is simply floored to 1000, hence the mismatch. We just need to add spring config `spring.data.rest.max-page-size` in `application.properties` to override this

    - I am not satisfied with this fix since it involves modifying existing config which is undesireable for fixes in general. I'm checking out some other solutions which involves writing new `@Configuration` and some more [here](https://stackoverflow.com/questions/27032433/set-default-page-size-for-jpa-pageable-object). I look forward to recommendations.

# Instructions for Reviewers
1. For 8576, run request `/server/api/discover/search?scope=abcd&configuration=default-relationships`

2. For 8577, run request `/server/api/core/items/ae181f94-0dc1-44cd-8024-b8e1db439c43/bundles?embed=bitstreams/format&size=9999`

Code Contribution Checklist
- [x] PRs _should_ be smaller in size (ideally less than 1,000 lines of code, not including comments & tests)
- [x] PRs **must** pass Checkstyle validation based on our [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] PRs **must** include Javadoc for _all new/modified public methods and classes_. Larger private methods should also have Javadoc
- [x] PRs **must** pass all automated tests and include new/updated Unit or Integration tests based on our [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If a PR includes new libraries/dependencies (in any `pom.xml`), then their software licenses **must** align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] Basic technical documentation _should_ be provided for any new features or changes to the REST API. REST API changes should be documented in our [Rest Contract](https://github.com/DSpace/RestContract).
- [x] If a PR fixes an issue ticket, please [link them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).